### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install vue-longpress --save
 ## Example
 
 ```js
-import {Longpress} from 'vue-longpress';
+import Longpress from 'vue-longpress';
 
 var vm = new Vue({
 	el: '#app',


### PR DESCRIPTION
Longpress is a default export. `import {Longpress} from "vue-longpress"` won't work.