### PR TITLE
Handling undefined pressingText

### DIFF
--- a/src/longpress-button.vue
+++ b/src/longpress-button.vue
@@ -73,7 +73,8 @@ export default {
 
     computed: {
         countingPressingText() {
-            return this.pressingText
+            const pressingText = this.pressingText || '';
+            return pressingText
                 .replace(/\{\$counter\}/gi, this.counter)
                 .replace(/\{\$rcounter\}/gi, this.duration - this.counter)
                 .replace(/\{\$duration\}/gi, this.duration);


### PR DESCRIPTION
Fixes https://github.com/javisperez/vuelongpress/issues/3, This should prevent any crashes when `pressingText` is undefined.